### PR TITLE
Fix flutter version in Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,9 +13,14 @@ jobs:
       matrix:
         format: [darwin-dmg, darwin-pkg, linux-appimage, linux-deb, linux-rpm, linux-snap, windows-msi]
     container:
-      image: goflutter/hover:v0.42.0
+      image: goflutter/hover:v0.43.0
 
     steps:
+      - name: Update flutter
+        run: |
+          apt-get update
+          apt-get install -y unzip
+          flutter upgrade
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0


### PR DESCRIPTION
Updates the hover image which contains an old flutter beta version which is too old for https://github.com/go-flutter-desktop/examples/pull/111